### PR TITLE
Simplify code with grep options and less hardcoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var printIssue = function(fileName, lineNum, matchedString){
 
 var findFixmes = function(file){
   // Prepare the grep string for execution (uses BusyBox grep)
-  var grepString = "grep -iInHwoE '(" + fixmeStrings.join("|") + ")' " + file;
+  var grepString = "grep -d skip -iInHwoE '(" + fixmeStrings.join("|") + ")' " + file;
 
   // Execute grep with the FIXME patterns
   exec(grepString, function (error, stdout, stderr) {
@@ -43,16 +43,15 @@ var findFixmes = function(file){
       var lines = results.split("\n");
       
       lines.forEach(function(line, index, array){
-        // grep spits out an extra line that we can ignore
-        if(index < (array.length-1)){
-          // Grep output is colon delimited
-          var cols = line.split(":");
+        // Grep output is colon delimited
+        var cols = line.split(":");
 
-          // Remove remnants of container paths for external display
-          var fileName = cols[0].split("/code/")[1];
-          var lineNum = cols[1];
-          var matchedString = cols[2];
+        // Remove remnants of container paths for external display
+        var fileName = cols[0].split("/code/")[1];
+        var lineNum = cols[1];
+        var matchedString = cols[2];
 
+        if (matchedString !== undefined){
           printIssue(fileName, lineNum, matchedString);
         }
       })

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = FixMe;
 function FixMe() { }
 
 // Strings to scan for in source
-var fixmeStrings = "'(FIXME|TODO|HACK|XXX|BUG)'";
+var fixmeStrings = ["FIXME", "TODO", "HACK", "XXX", "BUG"];
 
 // Prints properly structured Issue data to STDOUT according to
 // Code Climate Engine specification.
@@ -32,7 +32,7 @@ var printIssue = function(fileName, lineNum, matchedString){
 
 var findFixmes = function(file){
   // Prepare the grep string for execution (uses BusyBox grep)
-  var grepString = "grep -iInHwoE " + fixmeStrings + " " + file;
+  var grepString = "grep -iInHwoE '(" + fixmeStrings.join("|") + ")' " + file;
 
   // Execute grep with the FIXME patterns
   exec(grepString, function (error, stdout, stderr) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ function FixMe() { }
 // Strings to scan for in source
 var fixmeStrings = ["FIXME", "TODO", "HACK", "XXX", "BUG"];
 
+var sourcePathPrefix = "/code/";
+var configJSONPath = "/config.json";
+
 // Prints properly structured Issue data to STDOUT according to
 // Code Climate Engine specification.
 var printIssue = function(fileName, lineNum, matchedString){
@@ -47,7 +50,7 @@ var findFixmes = function(file){
         var cols = line.split(":");
 
         // Remove remnants of container paths for external display
-        var fileName = cols[0].split("/code/")[1];
+        var fileName = cols[0].split(sourcePathPrefix)[1];
         var lineNum = cols[1];
         var matchedString = cols[2];
 
@@ -63,10 +66,10 @@ var findFixmes = function(file){
 // excluding files passed in with by CLI config
 var fileWalk = function(excludePaths){
   var analysisFiles = [];
-  var allFiles = glob.sync("/code/**/**", {});
+  var allFiles = glob.sync(sourcePathPrefix+"**/**", {});
 
   allFiles.forEach(function(file, i, a){
-    if(excludePaths.indexOf(file.split("/code/")[1]) < 0) {
+    if(excludePaths.indexOf(file.split(sourcePathPrefix)[1]) < 0) {
       if(!fs.lstatSync(file).isDirectory()){
         analysisFiles.push(file);
       }
@@ -79,8 +82,8 @@ var fileWalk = function(excludePaths){
 FixMe.prototype.runEngine = function(){
 
   // Check for existence of config.json, parse exclude paths if it exists
-  if (fs.existsSync("/config.json")) {
-    var engineConfig = JSON.parse(fs.readFileSync("/config.json"));
+  if (fs.existsSync(configJSONPath)) {
+    var engineConfig = JSON.parse(fs.readFileSync(configJSONPath));
     var excludePaths = engineConfig.exclude_paths;
   } else {
     var excludePaths = [];


### PR DESCRIPTION
By using grep's built-in options -I and -d, one can achieve the same goals as are achieved by conditionals and tests in the current code. This eliminates the need for an entire module ("path") and reduces code complexity.

Instead of using a pipe-delimited string and injecting it directly, it is safer and easier for future developers to manipulate a native array of patterns and compose the ORed set using Array.join("|").

Because hardcoded paths were used in multiple locations, DRY (and an aversion to magic values) drive me to create variables for them instead.