### PR TITLE
quote filename shelling out to grep

### DIFF
--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -35,7 +35,8 @@ FixMe.prototype.find = function(file){
       self = this;
 
   // Prepare the grep string for execution (uses BusyBox grep)
-  var grepString = "grep -inHwoE " + fixmeStrings + " " + file;
+  var grepString = ["grep -inHwoE", fixmeStrings, '"' + file + '"'].join(" ");
+
 
   // Execute grep with the FIXME patterns
   exec(grepString, function (error, stdout, stderr) {


### PR DESCRIPTION
If a path has a space in it, the grep will fail unless we quote the filename.