### PR TITLE
Update dockerfile to copy package.json before running npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,18 @@ FROM node
 
 MAINTAINER Michael R. Bernstein
 
-RUN useradd -u 9000 -r -s /bin/false app
+WORKDIR /usr/src/app/
+
+COPY engine.json /
+COPY package.json /usr/src/app/
 
 ENV NODE_ENV production
 
 RUN npm install
 
-WORKDIR /code
-COPY . /usr/src/app
-COPY engine.json /
-
+RUN useradd -u 9000 -r -s /bin/false app
 USER app
-VOLUME /code
+
+COPY . /usr/src/app
 
 CMD ["/usr/src/app/bin/fixme"]


### PR DESCRIPTION
We recently packaged codeclimate-fixme as a node module and so
updated the Dockerfile to run simply `npm install`, grabbing the
requisite dependencies from the package.json.

However, we need to make sure that the package.json gets copied
over first. This change fixes the Dockerfile and makes it look
more like the flow in some of our other engines.

E.g.: codeclimate-rubocop
https://github.com/codeclimate/codeclimate-rubocop/blob/master/Dockerfile

@codeclimate/review @GordonDiggs 