### PR TITLE
Allow configurability of the FIXME strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ These strings are things you should fix now, not later.
 2. Run `codeclimate engines:enable fixme`. This command both installs the engine and enables it in your `.codeclimate.yml` file.
 3. You're ready to analyze! Browse into your project's folder and run `codeclimate analyze`.
 
+### Configuration
+
+You can specify what strings to match by adding a `strings` key in your
+`.codeclimate.yml`:
+
+```yaml
+engines:
+  fixme:
+    enabled: true
+    strings:
+    - FIXME
+    - CUSTOM
+```
+
+**NOTE**: values specified here *override* the defaults, they are not
+*additional* strings to match.
+
 ### Need help?
 
 For help with `codeclimate-fixme`, please open an issue on this repository.

--- a/lib/file-builder.js
+++ b/lib/file-builder.js
@@ -6,14 +6,6 @@ function withIncludes(include_paths) {
   return buildFiles(include_paths);
 }
 
-// Returns file paths based on the exclude_paths values in config file
-function withExcludes(exclude_paths) {
-  var allFiles = glob.sync("/code/**/**", {});
-  var excludedFiles = buildFiles(exclude_paths);
-
-  return diff(allFiles, excludedFiles);
-}
-
 // Returns all the file paths in the main directory that match the given pattern
 function buildFiles(paths) {
   var files = [];
@@ -35,7 +27,6 @@ function filterFiles(paths) {
 
 module.exports = {
   withIncludes: withIncludes,
-  withExcludes: withExcludes,
   filterFiles: filterFiles
 };
 

--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -11,18 +11,20 @@ function FixMe() { }
 
 FixMe.prototype.runEngine = function(){
   var analysisFiles = [],
+      config = {
+        include_paths: ["./"]
+      },
       self = this;
 
   if (fs.existsSync('/config.json')) {
-    var engineConfig = JSON.parse(fs.readFileSync('/config.json'));
+    var overrides = JSON.parse(fs.readFileSync('/config.json'));
 
-    if (engineConfig.hasOwnProperty('include_paths')) {
-      analysisFiles = fileBuilder.withIncludes(engineConfig.include_paths);
-    } else if (engineConfig.hasOwnProperty('exclude_paths')) {
-      analysisFiles = fileBuilder.withExcludes(engineConfig.exclude_paths);
+    for (var prop in overrides) {
+        config[prop] = overrides[prop];
     }
   }
 
+  analysisFiles = fileBuilder.withIncludes(config.include_paths);
   analysisFiles = fileBuilder.filterFiles(analysisFiles);
 
   analysisFiles.forEach(function(f, i, a){

--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -12,7 +12,8 @@ function FixMe() { }
 FixMe.prototype.runEngine = function(){
   var analysisFiles = [],
       config = {
-        include_paths: ["./"]
+        include_paths: ["./"],
+        strings: ["FIXME", "TODO", "HACK", "XXX", "BUG"]
       },
       self = this;
 
@@ -28,12 +29,12 @@ FixMe.prototype.runEngine = function(){
   analysisFiles = fileBuilder.filterFiles(analysisFiles);
 
   analysisFiles.forEach(function(f, i, a){
-    self.find(f);
+    self.find(f, config.strings);
   });
 }
 
-FixMe.prototype.find = function(file){
-  var fixmeStrings = "'(FIXME|TODO|HACK|XXX|BUG)'",
+FixMe.prototype.find = function(file, strings){
+  var fixmeStrings = "'(" + strings.join("|") + ")'",
       self = this;
 
   // Prepare the grep string for execution (uses BusyBox grep)

--- a/test/file-builder.js
+++ b/test/file-builder.js
@@ -7,11 +7,6 @@ describe("fileBuilder", function(){
       // expect();
     });
   });
-  describe("#withExcludes(paths)", function(){
-    xit("returns correct files", function(){
-      // expect();
-    });
-  });
   describe("#filterFiles(paths)", function(){
     xit("returns filters out directory paths", function(){
       // expect();


### PR DESCRIPTION
See the `README.md` diff for details.

Also drops `exclude_paths` support and defaults `include_paths` to `["./"]`
when unspecified (for easier development).

/cc @codeclimate/review @mrb