### PR TITLE
customize strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ You can specify what strings to match by adding a `strings` key in your
 engines:
   fixme:
     enabled: true
-    strings:
-    - FIXME
-    - CUSTOM
+    config:
+      strings:
+      - FIXME
+      - CUSTOM
 ```
 
 **NOTE**: values specified here *override* the defaults, they are not

--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -18,10 +18,14 @@ FixMe.prototype.runEngine = function(){
       self = this;
 
   if (fs.existsSync('/config.json')) {
-    var overrides = JSON.parse(fs.readFileSync('/config.json'));
+    var userConfig = JSON.parse(fs.readFileSync('/config.json'));
 
-    for (var prop in overrides) {
-        config[prop] = overrides[prop];
+    config.include_paths = userConfig.include_paths;
+
+    if (userConfig.config) {
+      for (var prop in userConfig.config) {
+        config[prop] = userConfig.config[prop];
+      }
     }
   }
 


### PR DESCRIPTION
We need to nest the `strings` config option under a wildcard engine `config` key that `cc/yaml` allows.

@codeclimate/review  @pbrisbin 