### PR TITLE
fix filename bug

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,4 +10,4 @@ exclude_paths:
 - "**/*.md"
 - "Dockerfile"
 - "bin/fixme"
-- "tests/**"
+- "test/**"

--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -44,7 +44,6 @@ FixMe.prototype.find = function(file, strings){
   // Prepare the grep string for execution (uses BusyBox grep)
   var grepString = ["grep -nHwoE", fixmeStrings, '"' + file + '"'].join(" ");
 
-
   // Execute grep with the FIXME patterns
   exec(grepString, function (error, stdout, stderr) {
     var results = stdout.toString();
@@ -55,12 +54,12 @@ FixMe.prototype.find = function(file, strings){
 
       lines.forEach(function(line, index, array){
         // grep spits out an extra line that we can ignore
-        if(index < (array.length-1)){
+        if (index < (array.length-1)) {
           // Grep output is colon delimited
           var cols = line.split(":");
 
           // Remove remnants of container paths for external display
-          var fileName = cols[0].split("/code/")[1];
+          var fileName = self.formatPath(cols[0]);
           var lineNum = cols[1];
           var matchedString = cols[2];
 
@@ -91,4 +90,8 @@ FixMe.prototype.printIssue = function(fileName, lineNum, matchedString) {
 
   var issueString = JSON.stringify(issue)+"\0";
   console.log(issueString);
+}
+
+FixMe.prototype.formatPath = function(path) {
+  return path.replace(/^\/code\//, '');
 }

--- a/test/fix-me.js
+++ b/test/fix-me.js
@@ -1,5 +1,7 @@
-var expect = require('chai').expect
-var fixMe = require('../lib/fix-me.js')
+var expect = require('chai').expect,
+    intercept = require("intercept-stdout"),
+    fixMe = require('../lib/fix-me.js'),
+    engine = new fixMe;
 
 describe("fixMe", function(){
   describe("#runEngine()", function(){
@@ -7,9 +9,32 @@ describe("fixMe", function(){
       // expect();
     });
   });
-  describe("#find(file)", function(){
-    xit("finds target fixme keywords", function(){
-      // expect();
+
+  describe('#find(file)', function(){
+    it('finds and correctly prints TODO issues', function(done){
+      var capturedText = "",
+          unhookIntercept = intercept(function(txt) {
+            capturedText += txt;
+          });
+
+      engine.find('test/fixtures/code/src/code/test.js', ["FIXME", "TODO", "HACK", "XXX", "BUG"]);
+
+      // to capture standard output from engine, wait.
+      setTimeout(function() {
+          unhookIntercept();
+
+          expect(capturedText).to.eq('{"type":"issue","check_name":"TODO","description":"TODO found","categories":["Bug Risk"],"location":{"path":"test/fixtures/code/src/code/test.js","lines":{"begin":5,"end":5}}}\0\n');
+          done();
+      }, 10);
+    });
+  });
+
+  describe('#formatPath(path)', function(){
+    it('returns correct filename for files with /code in them', function(){
+      var path = '/code/src/javascripts/code/test.js',
+          formatted = engine.formatPath(path);
+
+      expect(formatted).to.eq('src/javascripts/code/test.js');
     });
   });
 });

--- a/test/fixtures/code/src/code/test.js
+++ b/test/fixtures/code/src/code/test.js
@@ -1,0 +1,6 @@
+
+function() {
+  console.log("hello world!");
+}
+// TODO
+// SUP


### PR DESCRIPTION
Don't take first element after splitting on '/code/', bc creates a
bug when `/code` is included in source code file path.

Add spec.

cc @codeclimate/review