### PR TITLE
Add intercept-stdout to package.json for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "chai": "3.4.1",
-    "mocha": "2.3.3"
+    "mocha": "2.3.3",
+    "intercept-stdout": "0.1.2"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
I built the node_modules locally in previous commit and forgot to include this in package.json.

This change updates package.json correctly.

@codeclimate/review 