### PR TITLE
Invoke grep only once per run

### DIFF
--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -1,5 +1,5 @@
 var glob = require('glob'),
-    exec = require('child_process').exec,
+    spawn = require('child_process').spawn,
     fs = require('fs'),
     path = require('path'),
     diff = require('./diff'),
@@ -32,21 +32,16 @@ FixMe.prototype.runEngine = function(){
   analysisFiles = fileBuilder.withIncludes(config.include_paths);
   analysisFiles = fileBuilder.filterFiles(analysisFiles);
 
-  analysisFiles.forEach(function(f, i, a){
-    self.find(f, config.strings);
-  });
+  self.find(analysisFiles, config.strings);
 }
 
-FixMe.prototype.find = function(file, strings){
-  var fixmeStrings = "'(" + strings.join("|") + ")'",
-      self = this;
+FixMe.prototype.find = function(files, strings){
+  var fixmeStrings = '(' + strings.join('|') + ')';
+  var grep = spawn('grep', ['-nHwoEr', fixmeStrings].concat(files));
+  var self = this;
 
-  // Prepare the grep string for execution (uses BusyBox grep)
-  var grepString = ["grep -nHwoE", fixmeStrings, '"' + file + '"'].join(" ");
-
-  // Execute grep with the FIXME patterns
-  exec(grepString, function (error, stdout, stderr) {
-    var results = stdout.toString();
+  grep.stdout.on('data', function (data) {
+    var results = data.toString();
 
     if (results !== ""){
       // Parses grep output
@@ -69,7 +64,7 @@ FixMe.prototype.find = function(file, strings){
         }
       })
     }
-  })
+  });
 }
 
 FixMe.prototype.printIssue = function(fileName, lineNum, matchedString) {


### PR DESCRIPTION
Previously we were running grep for each path passed to us in the
workspace. This led to situations where we had tens of thousands of
zombie processes waiting for the parent to exit on large repos.
Instead, invoke grep recursively for all files in the workspace a
single time.

* Use spawn instead of exec to stream results back

@codeclimate/review