### PR TITLE
Don't try to parse output until finished

### DIFF
--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -38,14 +38,17 @@ FixMe.prototype.runEngine = function(){
 FixMe.prototype.find = function(files, strings){
   var fixmeStrings = '(' + strings.join('|') + ')';
   var grep = spawn('grep', ['-nHwoEr', fixmeStrings].concat(files));
+  var output = "";
   var self = this;
 
-  grep.stdout.on('data', function (data) {
-    var results = data.toString();
+  grep.stdout.on('data', function(data) {
+    output += data.toString();
+  });
 
-    if (results !== ""){
+  grep.on('exit', function() {
+    if (output !== ""){
       // Parses grep output
-      var lines = results.split("\n");
+      var lines = output.split("\n");
 
       lines.forEach(function(line, index, array){
         // grep spits out an extra line that we can ignore


### PR DESCRIPTION
I switched to spawn from exec in order to try to stream issues as they
were reported by grep but node will pass chunks of output that may not
terminate with a line break causing a line to straddle two chunks. For
now buffer all of the data and output issues on exit. In another PR
I'll clean this up.

@codeclimate/review