### PR TITLE
Correct GitHub Issues link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ engines:
 
 For help with `codeclimate-fixme`, please open an issue on this repository.
 
-If you're running into a Code Climate issue, first look over this project's [GitHub Issues](https://github.com/codeclimate/codeclimate-watson/issues), as your question may have already been covered. If not, [go ahead and open a support ticket with us](https://codeclimate.com/help).
+If you're running into a Code Climate issue, first look over this project's [GitHub Issues](https://github.com/codeclimate/codeclimate-fixme/issues), as your question may have already been covered. If not, [go ahead and open a support ticket with us](https://codeclimate.com/help).


### PR DESCRIPTION
It seems like the issues link was incorrect? Fixed :) 