### PR TITLE
Ignore unparsable stdout

### DIFF
--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -44,6 +44,12 @@ FixMe.prototype.find = function(paths, strings, callback) {
     var path = parts[0].replace(/^\/code\//, '');
     var lineNumber = parseInt(parts[1], 10);
     var matchedString = parts[2];
+
+    if (!path || !lineNumber || !matchedString) {
+      process.stderr.write("Ignoring malformed output: " + line + "\n");
+      return;
+    }
+
     var issue = {
       'categories': ['Bug Risk'],
       'check_name': matchedString,


### PR DESCRIPTION
Looking at the full stack from this bugsnag[1]

    NoMethodError: undefined method `-' for nil:NilClass

Originating from:

    begin_index = lines.fetch("begin") - 1

This tells me an engine output { begin: null }. The events for this
errored build show it was a fixme engine that did this.

It looks like grep outputting to stdout something that doesn't match the
expected format could easily cause this:

    var parts = line.split(':');
    // => ["the whole line"]

    var lineNumber = parseInt(parts[1], 10);
    // => NaN

    var issue = {
      'location': {
        'begin': lineNumber,
        // => 'begin': NaN
    }

    this.output.write(JSON.stringify(issue) //...
    // {"begin":null}

An assertion that we have all the values we expected before printing the
issue should prevent downstream errors.

NOTE: CLI validations would catch this, since they run before the output
filter. In builder's case, the output filter runs before validations so
invalid issues can get in there and cause these errors. Addressing this
is a larger track of work, so fixing misbehaving engines is valuable in
the meantime.

1: https://bugsnag.com/code-climate/builder/errors/57546cf2be3f29e6a63111c8?event_id=5769f0b4076813321236b4e1

/cc @codeclimate/review @mrb