### PR TITLE
Ignore fixme comments in .codeclimate.yml

### DIFF
--- a/lib/fix-me.js
+++ b/lib/fix-me.js
@@ -50,6 +50,8 @@ FixMe.prototype.find = function(paths, strings, callback) {
       return;
     }
 
+    if(path.indexOf('.codeclimate.yml') !== -1) { return; }
+
     var issue = {
       'categories': ['Bug Risk'],
       'check_name': matchedString,

--- a/test/fix-me.js
+++ b/test/fix-me.js
@@ -59,6 +59,18 @@ describe("fixMe", function(){
 
       engine.run(engineConfig);
     });
+
+    it('ignores .codeclimate.yml', function(done) {
+      var buf = new IssueBuffer();
+      var engine = new FixMe(buf);
+
+      engine.find(['test/fixtures/'], ['URGENT'], function() {
+        var issues = buf.toIssues();
+        expect(issues.length).to.eq(1);
+        expect(issues[0].location.path).to.eq('test/fixtures/urgent.js');
+        done();
+      });
+    });
   });
 
   describe('#find(paths, strings)', function() {

--- a/test/fixtures/.codeclimate.yml
+++ b/test/fixtures/.codeclimate.yml
@@ -1,0 +1,6 @@
+engines:
+  fixme:
+    enabled: true
+    config:
+      strings:
+        - URGENT

--- a/test/fixtures/urgent.js
+++ b/test/fixtures/urgent.js
@@ -1,0 +1,2 @@
+// URGENT: this is busted
+console.log("busted");


### PR DESCRIPTION
If you're using custom strings, we'll find those strings in config file
where you specify those custom strings, and create some issues. That
seems less than helpful.

Close #45 